### PR TITLE
Refactor SQLAlchemy object retrieval

### DIFF
--- a/wechat_auto_sender_full_en/db_utils.py
+++ b/wechat_auto_sender_full_en/db_utils.py
@@ -70,7 +70,7 @@ def add_transaction(
     return t
 
 def recalc_subscription_balance(s, subscription_id: int):
-    sub = s.query(Subscription).get(subscription_id)
+    sub = s.get(Subscription, subscription_id)
     if not sub:
         return None
     bottle_sum = (

--- a/wechat_auto_sender_full_en/hook.py
+++ b/wechat_auto_sender_full_en/hook.py
@@ -136,7 +136,7 @@ def process_one_task(task_id: int):
     from sender import send_text_lines  # 延迟导入，便于单元测试与可选依赖
 
     with session_scope() as s:
-        task: Task | None = s.query(Task).get(task_id)
+        task: Task | None = s.get(Task, task_id)
         if not task:
             logger.warning(f"Task#{task_id} not found.")
             return


### PR DESCRIPTION
## Summary
- refactor subscription lookup to use `Session.get`
- use `Session.get` when processing tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hooks'; ModuleNotFoundError: No module named 'pyautogui')*

------
https://chatgpt.com/codex/tasks/task_e_68c4cb5d9bc8832f8bfff1a3f30d67d4