### PR TITLE
feat: make input box configurable

### DIFF
--- a/wechat_auto_sender_full_en/USER_GUIDE.md
+++ b/wechat_auto_sender_full_en/USER_GUIDE.md
@@ -1,3 +1,23 @@
 # USER GUIDE — WeChat Auto Sender
 
 ... (内容同上，省略这里的预览以节省篇幅) ...
+
+## Setting the input box position
+
+The script clicks the chat input box before pasting messages.  Different screen
+resolutions mean the coordinates vary from machine to machine.  You can measure
+the coordinates in a Python shell:
+
+```python
+>>> import pyautogui as gui
+>>> gui.position()  # move your mouse to the input box first
+```
+
+Take the returned `(x, y)` and set it in `config.py`:
+
+```python
+INPUT_BOX_POS = (x, y)
+```
+
+After saving, the sender will use your customised position instead of the
+built‑in default.

--- a/wechat_auto_sender_full_en/config.py
+++ b/wechat_auto_sender_full_en/config.py
@@ -39,3 +39,6 @@ MAX_RETRY = 3
 NIGHT_SILENT = False
 NIGHT_START = 22   # 晚上 22 点后不发
 NIGHT_END = 7      # 早上 7 点前不发
+
+# 微信输入框的点击位置 (x, y)，需根据屏幕实际情况测量
+INPUT_BOX_POS = (1275, 850)

--- a/wechat_auto_sender_full_en/sender.py
+++ b/wechat_auto_sender_full_en/sender.py
@@ -24,12 +24,13 @@ except Exception:  # pragma: no cover
 
 # 可从 config 读取的选项（给默认值，兼容你的极简 config.py）
 try:
-    from config import DRY_RUN, AUDIT_DIR, SAFE_GAP_PER_MSG, JITTER_SECONDS
+    from config import DRY_RUN, AUDIT_DIR, SAFE_GAP_PER_MSG, JITTER_SECONDS, INPUT_BOX_POS
 except Exception:
     DRY_RUN = True
     AUDIT_DIR = "audit"
     SAFE_GAP_PER_MSG = 3.5
     JITTER_SECONDS = (0.8, 2.2)
+    INPUT_BOX_POS = (1275, 850)
 
 def _jitter(a=0.8, b=2.2):
     time.sleep(random.uniform(a, b))
@@ -81,8 +82,8 @@ def _find_and_open_contact(name: str):
     # _jitter(0.3, 0.5)   # 给微信反应时间
     # gui.press("enter")  # 再按一次，确保进入聊天
     _human_pause(0.6)
-    # 👇 点击输入框位置（x,y需要你自己量一下）
-    gui.click(1275, 850)   # 假设输入框大概在屏幕底部
+    # 👇 点击输入框位置（可在 config.py 中配置 INPUT_BOX_POS）
+    gui.click(*INPUT_BOX_POS)
     _human_pause(0.3)
 
 def send_text_lines(contact_name: str, lines: list[str]):


### PR DESCRIPTION
## Summary
- allow configuring chat input box location via `INPUT_BOX_POS`
- use the new config in sender logic instead of fixed coordinates
- document how to measure and set coordinates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hooks'; No module named 'pyautogui`)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cb63e6e0832f9ad832adfb5f99d3